### PR TITLE
Adding link query

### DIFF
--- a/src/JSONDB/Benchmark.php
+++ b/src/JSONDB/Benchmark.php
@@ -59,7 +59,8 @@
          * @return void
          */
         public function mark( $name ) {
-            self::$marker[$name] = microtime( ) ;
+            self::$marker[$name]['e'] = microtime( ) ;
+            self::$marker[$name]['m'] = memory_get_usage( ) ;
         }
 
         /**
@@ -73,24 +74,41 @@
             if ( $point1 === '' ) {
                 return '{elapsed_time}' ;
             }
-            if ( !array_key_exists( $point1, self::$marker )) {
+            if ( !array_key_exists( $point1, self::$marker ) ) {
                 return '' ;
             }
-            if ( !array_key_exists( $point2, self::$marker )) {
-                self::$marker[$point2] = microtime( ) ;
+            if ( !array_key_exists( $point2, self::$marker ) ) {
+                self::$marker[$point2]['e'] = microtime( ) ;
+                self::$marker[$point2]['m'] = memory_get_usage( ) ;
             }
-            list( $sm, $ss ) = explode( ' ', self::$marker[$point1] ) ;
-            list( $em, $es ) = explode( ' ', self::$marker[$point2] ) ;
+            list( $sm, $ss ) = explode( ' ', self::$marker[$point1]['e'] ) ;
+            list( $em, $es ) = explode( ' ', self::$marker[$point2]['e'] ) ;
 
             return number_format( ( $em + $es ) - ( $sm + $ss ), $decimals ) ;
         }
 
         /**
          * Calculate the memory usage of a benchmark point
-         * @return int
+         * @param  string  $point1    The name of the first benchmark point
+         * @param  string  $point2    The name of the second benchmark point
+         * @param  int     $decimals
+         * @return mixed
          */
-        public function memory_usage( ) {
-            return memory_get_usage();
+        public function memory_usage( $point1 = '', $point2 = '', $decimals = 4 ) {
+            if ( $point1 === '' ) {
+                return '{memory_usage}' ;
+            }
+            if ( !array_key_exists( $point1, self::$marker ) ) {
+                return '' ;
+            }
+            if ( !array_key_exists( $point2, self::$marker ) ) {
+                self::$marker[$point2]['e'] = microtime( ) ;
+                self::$marker[$point2]['m'] = memory_get_usage( ) ;
+            }
+            $sm = self::$marker[$point1]['m'] ;
+            $em = self::$marker[$point2]['m'] ;
+
+            return number_format( $em - $sm , $decimals ) ;
         }
 
     }

--- a/src/JSONDB/QueryParser.php
+++ b/src/JSONDB/QueryParser.php
@@ -185,6 +185,20 @@
                     case 'group':
                         $extensions['group'] = $this->_parseGroupExtension($string);
                         break;
+
+                    case 'on':
+                        if (!array_key_exists('on', $extensions)) {
+                            $extensions['on'] = array();
+                        }
+                        $extensions['on'][] = $this->_parseOnExtension($string);
+                        break;
+
+                    case 'link':
+                        if (!array_key_exists('link', $extensions)) {
+                            $extensions['link'] = array();
+                        }
+                        $extensions['link'][] = $this->_parseLinkExtension($string);
+                        break;
                 }
             }
             $this->parsedQuery['extensions'] = $extensions;
@@ -379,10 +393,36 @@
             }, explode(',', $clause));
             $parsedClause = NULL !== $parsedClause[0] ? $parsedClause : array();
             if (count($parsedClause) === 0) {
-                throw new Exception("JSONDB Query Parse Error: At least one parameter expected for the \"as()\" extension.");
+                throw new Exception("JSONDB Query Parse Error: At least one parameter expected for the \"group()\" extension.");
             }
             if (count($parsedClause) > 1) {
                 throw new Exception("JSONDB Query Parse Error: Too much parameters given to the \"group()\" extension, only one required.");
+            }
+
+            return $parsedClause;
+        }
+
+        private function _parseOnExtension($clause)
+        {
+            $parsedClause = array_map(function($field) {
+                return trim($field, self::TRIM_CHAR);
+            }, explode(',', $clause));
+            $parsedClause = NULL !== $parsedClause[0] ? $parsedClause : array();
+            if (count($parsedClause) === 0) {
+                throw new Exception("JSONDB Query Parse Error: At least one parameter expected for the \"on()\" extension.");
+            }
+
+            return $parsedClause;
+        }
+
+        private function _parseLinkExtension($clause)
+        {
+            $parsedClause = array_map(function($field) {
+                return trim($field, self::TRIM_CHAR);
+            }, explode(',', $clause));
+            $parsedClause = NULL !== $parsedClause[0] ? $parsedClause : array();
+            if (count($parsedClause) === 0) {
+                throw new Exception("JSONDB Query Parse Error: At least one parameter expected for the \"link()\" extension.");
             }
 
             return $parsedClause;

--- a/src/JSONDB/QueryParser.php
+++ b/src/JSONDB/QueryParser.php
@@ -205,7 +205,7 @@
 
             $this->parsedQuery['benchmark'] = array(
                 'elapsed_time' => $benchmark->elapsed_time('jsondb_query_parse_start', 'jsondb_query_parse_end'),
-                'memory_usage' => $benchmark->memory_usage()
+                'memory_usage' => $benchmark->memory_usage('jsondb_query_parse_start', 'jsondb_query_parse_end')
             );
 
             return $this->parsedQuery;
@@ -411,8 +411,11 @@
             if (count($parsedClause) === 0) {
                 throw new Exception("JSONDB Query Parse Error: At least one parameter expected for the \"on()\" extension.");
             }
+            if (count($parsedClause) > 1) {
+                throw new Exception("JSONDB Query Parse Error: Too much parameters given to the \"on()\" extension, only one required.");
+            }
 
-            return $parsedClause;
+            return $parsedClause[0];
         }
 
         private function _parseLinkExtension($clause)

--- a/src/JSONDB/QueryResult.php
+++ b/src/JSONDB/QueryResult.php
@@ -96,20 +96,37 @@
          */
         public function valid()
         {
-            if ($this->key === '#queryString') {
+            if ($this->key === '#queryString' || $this->key === '#elapsedtime' || $this->key === '#memoryusage') {
                 return FALSE;
             } else {
                 return array_key_exists($this->key, $this->results);
             }
         }
 
+        public function queryString()
+        {
+            return $this->database->queryString();
+        }
+
         /**
          * Returns the current result
-         * @return array
+         * @return array|QueryResultObject
+         * @throws Exception
          */
         public function current()
         {
-            return $this->results[$this->key];
+            $return = $this->results[$this->key];
+
+            switch ($this->fetchMode) {
+                case JSONDB::FETCH_ARRAY:
+                    return (array)$return;
+
+                case JSONDB::FETCH_OBJECT:
+                    return new QueryResultObject($return);
+
+                default:
+                    throw new Exception('JSONDB Query Result Error: Fetch mode not supported.');
+            }
         }
 
         /**
@@ -236,7 +253,7 @@
         {
             if ($this->offsetExists($offset)) {
                 unset($this->results[$offset]);
-                $this->_setResults(array_values(array_slice($this->results, 2)));
+                $this->_setResults(array_values(array_slice($this->results, 3)));
                 $this->_parseResults();
             }
         }
@@ -257,14 +274,7 @@
                 if ($this->valid()) {
                     $return = $this->current();
                     ++$this->key;
-
-                    switch ($this->fetchMode) {
-                        case JSONDB::FETCH_ARRAY:
-                            return (array)$return;
-
-                        case JSONDB::FETCH_OBJECT:
-                            return new QueryResultObject($return);
-                    }
+                    return $return;
                 }
                 return NULL;
             } else {
@@ -275,10 +285,12 @@
         /**
          * Changes the fetch mode
          * @param int $mode
+         * @return QueryResult
          */
         public function setFetchMode($mode = JSONDB::FETCH_ARRAY)
         {
             $this->fetchMode = $mode;
+            return $this;
         }
 
         /**
@@ -287,8 +299,9 @@
         private function _parseResults()
         {
             $this->results = array_merge(
-                array('#queryString' => $this->database->queryString(),
-                      '#elapsedtime' => $this->database->benchmark()->elapsed_time('jsondb_(query)_start', 'jsondb_(query)_end'))
+                array('#queryString' => $this->queryString(),
+                      '#elapsedtime' => $this->database->benchmark()->elapsed_time('jsondb_(query)_start', 'jsondb_(query)_end'),
+                      '#memoryusage' => $this->database->benchmark()->memory_usage('jsondb_(query)_start', 'jsondb_(query)_end'))
                 , $this->results);
         }
     }
@@ -334,6 +347,9 @@
         public function __get($name)
         {
             if (array_key_exists($name, $this->result)) {
+                if (is_array($this->result[$name])) {
+                    return new QueryResultObject($this->result[$name]);
+                }
                 return $this->result[$name];
             } else {
                 throw new Exception("JSONDB Query Result Error: Can't access the key \"{$name}\" in result, maybe the key doesn't exist.");


### PR DESCRIPTION
- Can now link tables when selecting data
- The link() extension work only with the select() query
- The link() extension can link two tables on() a column only if this one is of type link
- The link() extension can define column to extract from the second table
- Eg: table_name.select(foo, bar).on(bar).link(hello, world)
- Eg: table_name.select(bar).on(bar).link(*)
