### PR TITLE
Adding class mapping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.4
   - 5.5
   - 5.6
 script: phpunit

--- a/src/JSONDB/JSONDB.php
+++ b/src/JSONDB/JSONDB.php
@@ -76,13 +76,13 @@
          * Define if we fetch results as arrays
          * @const int
          */
-        const FETCH_ARRAY = 0;
+        const FETCH_ARRAY = 4;
 
         /**
          * Define if we fetch results as objects
          * @const int
          */
-        const FETCH_OBJECT = 1;
+        const FETCH_OBJECT = 5;
 
         /**
          * The current JSONDB instance

--- a/src/JSONDB/JSONDB.php
+++ b/src/JSONDB/JSONDB.php
@@ -85,6 +85,12 @@
         const FETCH_OBJECT = 5;
 
         /**
+         * Define if we fetch results as objects
+         * @const int
+         */
+        const FETCH_CLASS = 6;
+
+        /**
          * The current JSONDB instance
          * @var JSONDB
          */

--- a/src/JSONDB/QueryResult.php
+++ b/src/JSONDB/QueryResult.php
@@ -261,7 +261,7 @@
         /**
          * Fetch for results
          * @param int $mode The fetch mode
-         * @return array|QueryResultObject|null
+         * @return array|QueryResultObject|bool
          * @throws Exception
          */
         public function fetch($mode = NULL)
@@ -276,7 +276,7 @@
                     ++$this->key;
                     return $return;
                 }
-                return NULL;
+                return FALSE;
             } else {
                 throw new Exception("JSONDB Query Result Error: Can't fetch for results without execute the query.");
             }

--- a/tests/JSONDBTest.php
+++ b/tests/JSONDBTest.php
@@ -4,7 +4,6 @@ use JSONDB\JSONDB;
 
 class JSONDBTest extends PHPUnit_Framework_TestCase
 {
-
     /**
      * @var \JSONDB\JSONDB
      */
@@ -181,4 +180,54 @@ class JSONDBTest extends PHPUnit_Framework_TestCase
         self::$database->connect('__phpunit_test_server', '__phpunit', '', '__phpunit_test_database');
         self::$database->query('__phpunit_test_table_pk.replace(2)');
     }
+
+    /**
+     * @expectedException \JSONDB\Exception
+     */
+    public function testExceptionIsRaisedForFetchClassMode() {
+        $r = new \JSONDB\QueryResult(array(array('testVar1' => 'foo', 'testVar2' => 'bar')), self::$database);
+        $r->setFetchMode(\JSONDB\JSONDB::FETCH_CLASS, 'FakeClass');
+        $r->fetch();
+    }
+
+    /**
+     * @expectedException \JSONDB\Exception
+     */
+    public function testExceptionIsRaisedForFetchClassMode2() {
+        $r = new \JSONDB\QueryResult(array(array('testVar1' => 'foo', 'testVar3' => 'bar')), self::$database);
+        $r->setFetchMode(\JSONDB\JSONDB::FETCH_CLASS, 'TestClass');
+        $r->fetch();
+    }
+
+    /**
+     * @expectedException \JSONDB\Exception
+     */
+    public function testExceptionIsRaisedForFetchClassMode3() {
+        $r = new \JSONDB\QueryResult(array(array('testVar1' => 'foo', 'testVar4' => 'bar')), self::$database);
+        $r->setFetchMode(\JSONDB\JSONDB::FETCH_CLASS, 'TestClass');
+        $r->fetch();
+    }
+
+    public function testFetchClassMode() {
+        $r = new \JSONDB\QueryResult(array(array('testVar1' => 'foo', 'testVar2' => 'bar')), self::$database);
+        $r->setFetchMode(\JSONDB\JSONDB::FETCH_CLASS, 'TestClass');
+        $value = $r->current();
+        $this->assertInstanceOf('TestClass', $value);
+    }
+
+    public function testFetchClassMode2() {
+        $r = new \JSONDB\QueryResult(array(array('testVar1' => 'foo', 'testVar2' => 'bar')), self::$database);
+        $r->setFetchMode(\JSONDB\JSONDB::FETCH_CLASS, 'TestClass');
+        $value = $r->current();
+        $expected = new TestClass();
+        $expected->testVar1 = 'foo';
+        $expected->testVar2 = 'bar';
+        $this->assertEquals($expected, $value);
+    }
+}
+
+class TestClass {
+    public $testVar1;
+    public $testVar2;
+    private $testVar3;
 }


### PR DESCRIPTION
Query results can now be fetched with an user defined class.

**Exemple:**

``` php
class User {
    public $id;
    public $first_name;
    public $last_name;

    public function info()
    {
        return '#'.$this->id.': '.$this->first_name.' '.$this->last_name;
    }
}
```

Send a query and fetch results by mapping the class User:

``` php
$users = $db->query('users.select(id, first_name, last_name)');

while ($user = $users->fetch(\JSONDB\JSONDB::FETCH_CLASS, 'User') {
    echo $user->info();
}
```
